### PR TITLE
Add link to presentations

### DIFF
--- a/community.Rmd
+++ b/community.Rmd
@@ -6,3 +6,6 @@ output:
     toc_float: false
 ---
 Teams from anywhere in the world are invited to submit forecasts once a week for one or more of the countries. Take a look at the [submission instructions](https://github.com/epiforecasts/covid19-forecast-hub-europe/wiki) and [get in touch](contact.html) with any questions.
+
+
+The ECDC hosts weekly calls which any forecasting team is welcome to join. Each week a different team is invited to present and discuss forecasting methods. Slides and extra content provided by the teams is provided [here](https://github.com/epiforecasts/covid19-forecast-hub-europe/tree/main/presentations).


### PR DESCRIPTION
Links to presentations from group meetings, stored in main forecast hub repo.

Linked with [PR 254 on the main repo](https://github.com/epiforecasts/covid19-forecast-hub-europe/pull/254)